### PR TITLE
Italian ae fix

### DIFF
--- a/ecvit.def
+++ b/ecvit.def
@@ -20,7 +20,7 @@
 \def\ecv@genderkey{\ecv@utf{Sesso}}
 % Footer
 \def\ecv@pagekey{\ecv@utf{Pagina}}
-\def\ecv@cvofkey{\ecv@utf{Curriculum vit\ae\}}
+\def\ecv@cvofkey{\ecv@utf{Curriculum vit\ae}}
 % Language table
 \def\ecv@mothertonguekey{\ecv@utf{Madrelingua}}
 \def\ecv@assesskey{\ecv@utf{Autovalutazione}}


### PR DESCRIPTION
Commit 7c0f5b6dfd3ad89f87cfdcdf97d500716b7a51e5 removed "et studiorum" from the cvofkey leaving a trailing "\" that causes errors when using the italian option.