### PR TITLE
Fix #29 again

### DIFF
--- a/europecv.cls
+++ b/europecv.cls
@@ -445,7 +445,7 @@
 \newcommand\ecvfootnote[1]{\def\ecv@rfoot{#1}}
 \ecvfootnote{}
 
-\AtBeginDocument{%
+\AddToHook{begindocument/before}{%
 
 \RequirePackage{etoolbox} %important for \AfterPreamble
 


### PR DESCRIPTION
See #29 and #30 for more details. This is a "recommit" of the original
change proposed by David Carlisle and pull requested by @scottkosty.

I needed this change to test #32 in the very latest TeX Live. I open this more or less as a reminder, because #29 and #30 are closed, but the issue is not resolved.

My two cents: As far as I can tell this is the best thing to do at least according to LaTeX developers and works in recent versions of TeX Live. Old versions of TeX Live also have old EuropeCV, so there is no problem if one doesn't mix versions.
